### PR TITLE
fix: remove defunct Google Apps Script Slack Community link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@
 ## Communities
 
 * [Google Apps Script Community](https://groups.google.com/forum/#!forum/google-apps-script-community) Google Groups
-* [Google Apps Script Slack Community](https://google-apps-script.slack.com) Slack
+
 * [Google Apps Script Facebook Community](https://www.facebook.com/groups/googleappsscript/) Facebook Group
 * [r/GoogleAppsScript](https://www.reddit.com/r/GoogleAppsScript) Reddit
 * [Google Apps Script Telegram Chat](https://t.me/googleappsscriptrc) Telegram


### PR DESCRIPTION
The Slack workspace at google-apps-script.slack.com no longer exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Facebook Community link to the Communities section.
  * Removed the Slack Community entry for Google Apps Script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->