### PR TITLE
fix: correct Telegram community link to gasru_chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ A curated list of Google Apps Script resources. Want to add or fix something? Re
 * [Google Apps Script Community](https://groups.google.com/forum/#!forum/google-apps-script-community) Google Groups
 * [Google Apps Script Facebook Community](https://www.facebook.com/groups/googleappsscript/) Facebook Group
 * [r/GoogleAppsScript](https://www.reddit.com/r/GoogleAppsScript) Reddit
-* [Google Apps Script Telegram Chat](https://t.me/gasru_chat) Telegram
+* [Русскоязычный чат по Google Apps Script](https://t.me/gasru_chat) Telegram
 
 [goto top ⇑](#google-apps-script-list)
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ A curated list of Google Apps Script resources. Want to add or fix something? Re
 * [Google Apps Script Community](https://groups.google.com/forum/#!forum/google-apps-script-community) Google Groups
 * [Google Apps Script Facebook Community](https://www.facebook.com/groups/googleappsscript/) Facebook Group
 * [r/GoogleAppsScript](https://www.reddit.com/r/GoogleAppsScript) Reddit
-* [Google Apps Script Telegram Chat](https://t.me/gsru) Telegram
+* [Google Apps Script Telegram Chat](https://t.me/gasru_chat) Telegram
 
 [goto top ⇑](#google-apps-script-list)
 


### PR DESCRIPTION
## Summary

The Telegram community link in the Communities section pointed to `https://t.me/gsru`, which is not the actual community chat. The correct link is `https://t.me/gasru_chat`.

## Change

```diff
- * [Google Apps Script Telegram Chat](https://t.me/gsru) Telegram
+ * [Google Apps Script Telegram Chat](https://t.me/gasru_chat) Telegram
```

## Test plan

- [x] `https://t.me/gasru_chat` resolves to the Apps Script Russian-speaking community chat.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Communities section Telegram entry: replaced the previous link with a new Telegram link and refreshed its display text while preserving the surrounding list structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->