### PR TITLE
Add Google Sheets & Workspace Apps Script snippets (Snippets > Collections)

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ A curated list of Google Apps Script resources. Want to add or fix something? Re
 
 * [Google Apps Script snippets ᕦʕ •ᴥ•ʔᕤ](https://apps-script-snippets.contributor.pw/)
 * [Collection of Apps Scripts for connecting to APIs](https://github.com/benlcollins/apps_script_apis)
+* [Google Sheets & Workspace Apps Script snippets](https://github.com/bulldo-gs/apps-script-snippets) Copy-paste functions for transposing ranges, multi-column sort, splitting names, duplicate highlighting, and spreadsheet-to-Calendar sync
 
 #### Spreadsheets
 

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ A curated list of Google Apps Script resources. Want to add or fix something? Re
 
 * [Google Apps Script snippets ᕦʕ •ᴥ•ʔᕤ](https://apps-script-snippets.contributor.pw/)
 * [Collection of Apps Scripts for connecting to APIs](https://github.com/benlcollins/apps_script_apis)
-* [Google Sheets & Workspace Apps Script snippets](https://github.com/bulldo-gs/apps-script-snippets) Copy-paste functions for transposing ranges, multi-column sort, splitting names, duplicate highlighting, and spreadsheet-to-Calendar sync
+* [Google Sheets & Workspace Apps Script snippets](https://github.com/bulldo-gs/apps-script-snippets) Copy-paste functions for transposing ranges, sorting multiple columns, splitting names, highlighting duplicates, and syncing spreadsheets to Calendar
 
 #### Spreadsheets
 


### PR DESCRIPTION
Adds a small collection of copy-paste Google Apps Script snippets for Google Sheets / Workspace under **Snippets → Collections**.

- Repo: https://github.com/bulldo-gs/apps-script-snippets (public, MIT)
- **Disclosure:** I maintain this project (published by bulldo.gs).

Inclusion checklist:
- Apps Script first — yes, the repo is entirely Apps Script snippets.
- Usable as published — free, MIT, copy-paste; no signup or paid service.
- Adoption/activity — created and committed this month; not archived.
- Not a duplicate — distinct from the existing Collections entries.
- Working links — repo and cited links resolve.
- Truthful description — matches the repo's contents.

Format: one entry, appended to the bottom of the subsection, `* [Title](url) Description`, no trailing period.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refined the description of the existing Google Sheets and Workspace Apps Script snippets collection.
  * Clarified the examples of available helpers, including sorting multiple columns, highlighting duplicates, and syncing spreadsheet data with Calendar.
  * No new functionality or public interfaces were added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->