### PR TITLE
Add google-maps-100-stops (route-URL custom function + research)

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ A curated list of Google Apps Script resources. Want to add or fix something? Re
 
 ### Snippets
 
+* [google-maps-100-stops](https://github.com/b4thefomo/google-maps-100-stops) A custom function that builds one Google Maps URL for up to 100 stops, with the research showing why it works
 #### Collections
 
 * [Google Apps Script snippets ᕦʕ •ᴥ•ʔᕤ](https://apps-script-snippets.contributor.pw/)


### PR DESCRIPTION
Adds [google-maps-100-stops](https://github.com/b4thefomo/google-maps-100-stops): documented research showing Google Maps path-form URLs route up to 100 stops (the interface caps at 10, the documented api=1 form at ~25), with a reproducible Playwright probe, dependency-free Python/Node URL builders, and an Apps Script custom function (=GMAPS_ROUTE_URL) usable in any sheet. MIT licensed. Happy to adjust placement or wording.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for a Google Maps resource that generates a Google Maps URL with up to 100 stops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->